### PR TITLE
feat: Extend load script to handle scenarios (stateful behaviour)

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,15 @@ const addMapping = (mappingData) => {
   });
 
   const postBody = JSON.stringify(mappingData);
+
+  if (mappingData.scenarioName || mappingData.requiredScenarioState || mappingData.newScenarioState) {
+      postBody.persistent = true;
+      postBody.priority = 1;
+      postBody.scenarioName = mappingData.scenarioName || '';
+      postBody.requiredScenarioState = mappingData.requiredScenarioState || '';
+      postBody.newScenarioState = mappingData.newScenarioState || '';
+  }
+
   request.write(postBody);
   request.end();
 };
@@ -67,10 +76,14 @@ fs.readdir(`${argv.mocks}/mappings`, (err, files) => {
 
       let stub = JSON.parse(data);
 
-      if (stub.response.bodyFileName) {
-        inlineBodyFile(stub)
+      if (Array.isArray(stub.mappings)) {
+        stub.mappings.forEach(mapping => { addMapping(mapping); });
       } else {
-        addMapping(stub);
+        if (stub.response.bodyFileName) {
+          inlineBodyFile(stub);
+        } else {
+          addMapping(stub);
+        }
       }
     });
 


### PR DESCRIPTION
Hey there,

First off, I want to say thanks for your work on this script. It has been a real time-saver for me and my team.

However, during development, I ran into some problems when switching from "normal" request mocks to scenarios that required stateful behavior. To address this issue, I updated your script to support loading scenarios.

In addition to that, my colleagues and I made some other changes, such as using async and await to ensure processing and adding options to reduce output. If you're interested, I can open another pull request with these changes.

Thanks again for your work,
David
